### PR TITLE
Support for google

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The [Spring Security OAuth](http://static.springsource.org/spring-security/oauth
 
 This project allows you to directly authenticate with the OAuth Provider in the first instance, rather than as a secondary step.
 I was unable to find a project that was easily extensible enough to do what I wanted, so this project was born.
-It has been tested against DailyCred.
+It has been tested against DailyCred and Google.
 
 Usage
 ----
@@ -45,18 +45,17 @@ Example usage:
     </authentication-manager>
 
     <beans:bean id="oauth2ServiceProperties" class="com.racquettrack.security.oauth.OAuth2ServiceProperties">
-        <beans:property name="accessTokenUri" value="https://www.dailycred.com/oauth/access_token"/>
-        <beans:property name="userAuthorisationUri" value="https://www.dailycred.com/connect"/>
+        <beans:property name="accessTokenUri" value="https://accounts.google.com/o/oauth2/token"/>
+        <beans:property name="userAuthorisationUri" value="https://accounts.google.com/o/oauth2/auth"/>
         <beans:property name="additionalAuthParams">
             <beans:map>
-                <beans:entry key="egKey1" value="egValue1"/>
-                <beans:entry key="egKey2" value="egValue2"/>
+                <beans:entry key="scope" value="https://www.googleapis.com/auth/userinfo.email"/>
             </beans:map>
         </beans:property>
-        <beans:property name="redirectUri" value="http://localhost:8080/oauth/callback"/>
+        <beans:property name="redirectUri" value="/oauth/callback"/>
         <beans:property name="clientId" value="${oauth2.client_id}"/>
         <beans:property name="clientSecret" value="${oauth2.client_secret}"/>
-        <beans:property name="userInfoUri" value="https://www.dailycred.com/graph/me.json"/>
+        <beans:property name="userInfoUri" value="https://www.googleapis.com/oauth2/v2/userinfo"/>
     </beans:bean>
 
     <beans:bean id="oAuth2UserDetailsService" class="com.racquettrack.security.oauth.OAuth2UserDetailsService">
@@ -65,13 +64,19 @@ Example usage:
     </bean>
 
 1.  Define your OAuth2ServiceProperties class. This class is a placeholder for the configuration of your OAuth Provider. Important properties are:
-userAuthorisationUri - This is the URI that a user will be redirected to on trying to authentication / hitting the Authentication Entry Point
-additionalAuthParams - Any additional query parameters that you want sent to the OAuth Provider as part of the authorisation redirect.
-redirectUri - This is the URI that the OAuth Provider will redirect the user to (on your site) if they successfully authenticate. Must be the same as the OAuth2AuthenticationFilter is listening on.
-accessTokenUri - This is the REST URI that should be called to obtain an access token from the code. This is called by the OAuth2AuthenticationFilter after the redirect from the OAuth Provider.
-clientId - Your client id, given to you by the OAuth Provider.
-clientSecret - Your client secret, given to you by the OAuth Provider. It is important to keep this secret.
-userInfoUri - The REST URI in the OAuth Provider's system, that will be called to obtain additional information, e.g. the user id, about the user once an access token has been obtained.
+
+    **userAuthorisationUri** - This is the URI that a user will be redirected to on trying to authentication / hitting the Authentication Entry Point
+
+    **additionalAuthParams** - Any additional query parameters that you want sent to the OAuth Provider as part of the authorisation redirect.
+
+    **redirectUri** - This is the URI that the OAuth Provider will redirect the user to (on your site) if they successfully authenticate. Must be the same as the OAuth2AuthenticationFilter is listening on. This can be an absolute or relative URI. Relative URI's will be resolved against the incoming request URI.
+
+    **accessTokenUri** - This is the REST URI that should be called to obtain an access token from the code. This is called by the OAuth2AuthenticationFilter after the redirect from the OAuth Provider.
+
+    **clientId** - Your client id, given to you by the OAuth Provider.
+    clientSecret - Your client secret, given to you by the OAuth Provider. It is important to keep this secret.
+
+    **userInfoUri** - The REST URI in the OAuth Provider's system, that will be called to obtain additional information, e.g. the user id, about the user once an access token has been obtained.
 
 2.  Define your OAuth2UserDetailsService. This is called by the (OAuth2)AuthenticationProvider. You must define a bean (userFacade above) that implements the OAuth2UserDetailsLoader. Accounts in your system are linked to those in the OAuth Provider by the user id; this class resolves the local accounts and creates them if a new uesr has been created in the OAuth Provider.
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <groupId>com.racquettrack</groupId>
     <artifactId>spring-security-oauth2-client</artifactId>
     <name>Spring Security OAuth2 Client</name>
-    <version>1.2-SNAPSHOT</version>
+    <version>1.3-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <url>https://github.com/pwheel/spring-security-oauth2-client</url>

--- a/pom.xml
+++ b/pom.xml
@@ -219,13 +219,6 @@
             </plugin>
             <!-- End Quality control plugins -->
         </plugins>
-      <extensions>
-        <extension>
-          <groupId>ar.com.synergian</groupId>
-          <artifactId>wagon-git</artifactId>
-          <version>0.2.3</version>
-        </extension>
-      </extensions>
     </build>
 
   <distributionManagement>
@@ -240,11 +233,4 @@
       <url>git:master://git@bitbucket.org:racquettrack/maven-repo-snapshots.git</url>
     </snapshotRepository>
   </distributionManagement>
-
-  <pluginRepositories>
-    <pluginRepository>
-      <id>synergian-repo</id>
-      <url>https://raw.github.com/synergian/wagon-git/releases</url>
-    </pluginRepository>
-  </pluginRepositories>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <groupId>com.racquettrack</groupId>
     <artifactId>spring-security-oauth2-client</artifactId>
     <name>Spring Security OAuth2 Client</name>
-    <version>1.3-SNAPSHOT</version>
+    <version>1.3-AUSCOPE-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <url>https://github.com/pwheel/spring-security-oauth2-client</url>

--- a/pom.xml
+++ b/pom.xml
@@ -191,6 +191,20 @@
                     <debug>true</debug>
                 </configuration>
             </plugin>
+            
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+                <executions>
+                  <execution>
+                    <id>attach-sources</id>
+                    <goals>
+                        <goal>jar</goal>
+                    </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            
             <!-- Quality control plugins to execute during build phase -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -17,8 +17,8 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <version.spring-security>3.1.1.RELEASE</version.spring-security>
-        <version.spring>3.1.1.RELEASE</version.spring>
+        <version.spring-security>3.2.4.RELEASE</version.spring-security>
+        <version.spring>3.2.10.RELEASE</version.spring>
         <version.javaJDK>1.7</version.javaJDK>
         <version.jersey>1.14</version.jersey>
         <version.commons-lang3>3.1</version.commons-lang3>

--- a/src/main/java/com/racquettrack/security/oauth/DefaultOAuth2UserInfoProvider.java
+++ b/src/main/java/com/racquettrack/security/oauth/DefaultOAuth2UserInfoProvider.java
@@ -1,6 +1,10 @@
 package com.racquettrack.security.oauth;
 
-import com.sun.jersey.api.client.*;
+import java.io.IOException;
+import java.util.Map;
+
+import javax.ws.rs.core.MediaType;
+
 import org.codehaus.jackson.map.ObjectMapper;
 import org.codehaus.jackson.type.TypeReference;
 import org.slf4j.Logger;
@@ -9,9 +13,11 @@ import org.springframework.beans.factory.InitializingBean;
 import org.springframework.security.core.Authentication;
 import org.springframework.util.Assert;
 
-import javax.ws.rs.core.MediaType;
-import java.io.IOException;
-import java.util.Map;
+import com.sun.jersey.api.client.Client;
+import com.sun.jersey.api.client.ClientHandlerException;
+import com.sun.jersey.api.client.ClientResponse;
+import com.sun.jersey.api.client.UniformInterfaceException;
+import com.sun.jersey.api.client.WebResource;
 
 /**
  * A default implementation of {@link OAuth2UserInfoProvider} that obtains a {@link Map} of properties
@@ -65,6 +71,12 @@ public class DefaultOAuth2UserInfoProvider implements OAuth2UserInfoProvider, In
         WebResource webResource = client
                 .resource(oAuth2ServiceProperties.getUserInfoUri())
                 .queryParam(oAuth2ServiceProperties.getAccessTokenName(), (String)token.getCredentials());
+
+        if (oAuth2ServiceProperties.getAdditionalInfoParams() != null) {
+            for (Map.Entry<String, String> entry : oAuth2ServiceProperties.getAdditionalInfoParams().entrySet()) {
+                webResource = webResource.queryParam(entry.getKey(), entry.getValue());
+            }
+        }
 
         ClientResponse clientResponse = webResource.accept(MediaType.APPLICATION_JSON_TYPE)
                 .get(ClientResponse.class);

--- a/src/main/java/com/racquettrack/security/oauth/OAuth2AuthenticationEntryPoint.java
+++ b/src/main/java/com/racquettrack/security/oauth/OAuth2AuthenticationEntryPoint.java
@@ -1,5 +1,12 @@
 package com.racquettrack.security.oauth;
 
+import java.io.IOException;
+import java.util.Map;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
 import org.apache.commons.lang3.RandomStringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -7,12 +14,6 @@ import org.springframework.beans.factory.InitializingBean;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.util.Assert;
-
-import javax.servlet.ServletException;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-import java.io.IOException;
-import java.util.Map;
 
 /**
  * Provides a {@link AuthenticationEntryPoint} for initiating the OAuth2 authentication process.
@@ -46,7 +47,7 @@ public class OAuth2AuthenticationEntryPoint implements AuthenticationEntryPoint,
                 .append("&")
                 .append(oAuth2ServiceProperties.getRedirectUriParamName())
                 .append("=")
-                .append(oAuth2ServiceProperties.getRedirectUri())
+                .append(oAuth2ServiceProperties.getAbsoluteRedirectUri(request))
                 .append("&")
                 .append(oAuth2ServiceProperties.getResponseTypeParamName())
                 .append("=")

--- a/src/main/java/com/racquettrack/security/oauth/OAuth2AuthenticationFilter.java
+++ b/src/main/java/com/racquettrack/security/oauth/OAuth2AuthenticationFilter.java
@@ -1,5 +1,13 @@
 package com.racquettrack.security.oauth;
 
+import java.io.IOException;
+import java.util.Map;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.HttpSession;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.InitializingBean;
@@ -8,13 +16,6 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.authentication.AbstractAuthenticationProcessingFilter;
 import org.springframework.util.Assert;
-
-import javax.servlet.ServletException;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-import javax.servlet.http.HttpSession;
-import java.io.IOException;
-import java.util.Map;
 
 /**
  * An implementation of a {@link AbstractAuthenticationProcessingFilter} that responds to responses from the OAuth
@@ -92,6 +93,7 @@ public class OAuth2AuthenticationFilter extends AbstractAuthenticationProcessing
 
         // Allow subclasses to set the "details" property
         setDetails(request, authRequest);
+        authRequest.setRedirectUri(oAuth2ServiceProperties.getAbsoluteRedirectUri(request));
 
         return this.getAuthenticationManager().authenticate(authRequest);
     }

--- a/src/main/java/com/racquettrack/security/oauth/OAuth2AuthenticationProvider.java
+++ b/src/main/java/com/racquettrack/security/oauth/OAuth2AuthenticationProvider.java
@@ -193,8 +193,13 @@ public class OAuth2AuthenticationProvider implements AuthenticationProvider, Ini
         values.add(oAuth2ServiceProperties.getGrantTypeParamName(), oAuth2ServiceProperties.getGrantType());
         values.add(oAuth2ServiceProperties.getClientIdParamName(), oAuth2ServiceProperties.getClientId());
         values.add(oAuth2ServiceProperties.getClientSecretParamName(), oAuth2ServiceProperties.getClientSecret());
-        values.add(oAuth2ServiceProperties.getRedirectUriParamName(), oAuth2ServiceProperties.getRedirectUri());
         values.add(oAuth2ServiceProperties.getCodeParamName(), (String)  authentication.getCredentials());
+
+        if (authentication instanceof OAuth2AuthenticationToken) {
+            values.add(oAuth2ServiceProperties.getRedirectUriParamName(), ((OAuth2AuthenticationToken) authentication).getRedirectUri());
+        } else {
+            values.add(oAuth2ServiceProperties.getRedirectUriParamName(), oAuth2ServiceProperties.getRedirectUri());
+        }
 
         WebResource webResource = client.resource(oAuth2ServiceProperties.getAccessTokenUri());
         ClientResponse clientResponse = webResource

--- a/src/main/java/com/racquettrack/security/oauth/OAuth2AuthenticationProvider.java
+++ b/src/main/java/com/racquettrack/security/oauth/OAuth2AuthenticationProvider.java
@@ -1,6 +1,10 @@
 package com.racquettrack.security.oauth;
 
-import com.sun.jersey.api.client.*;
+import java.io.IOException;
+import java.util.Map;
+
+import javax.ws.rs.core.MediaType;
+
 import org.codehaus.jackson.map.ObjectMapper;
 import org.codehaus.jackson.type.TypeReference;
 import org.slf4j.Logger;
@@ -17,9 +21,12 @@ import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsChecker;
 import org.springframework.util.Assert;
 
-import javax.ws.rs.core.MediaType;
-import java.io.IOException;
-import java.util.Map;
+import com.sun.jersey.api.client.Client;
+import com.sun.jersey.api.client.ClientHandlerException;
+import com.sun.jersey.api.client.ClientResponse;
+import com.sun.jersey.api.client.UniformInterfaceException;
+import com.sun.jersey.api.client.WebResource;
+import com.sun.jersey.core.util.MultivaluedMapImpl;
 
 /**
  * Processes an OAuth2 authentication request. The request will typically originate from a
@@ -182,14 +189,18 @@ public class OAuth2AuthenticationProvider implements AuthenticationProvider, Ini
     private ClientResponse getClientResponseForAccessTokenRequestFrom(Authentication authentication) {
         Client client = getClient();
 
-        WebResource webResource = client
-                .resource(oAuth2ServiceProperties.getAccessTokenUri())
-                .queryParam(oAuth2ServiceProperties.getGrantTypeParamName(), oAuth2ServiceProperties.getGrantType())
-                .queryParam(oAuth2ServiceProperties.getClientSecretParamName(), oAuth2ServiceProperties.getClientSecret())
-                .queryParam(oAuth2ServiceProperties.getCodeParamName(), (String) authentication.getCredentials());
+        MultivaluedMapImpl values = new MultivaluedMapImpl();
+        values.add(oAuth2ServiceProperties.getGrantTypeParamName(), oAuth2ServiceProperties.getGrantType());
+        values.add(oAuth2ServiceProperties.getClientIdParamName(), oAuth2ServiceProperties.getClientId());
+        values.add(oAuth2ServiceProperties.getClientSecretParamName(), oAuth2ServiceProperties.getClientSecret());
+        values.add(oAuth2ServiceProperties.getRedirectUriParamName(), oAuth2ServiceProperties.getRedirectUri());
+        values.add(oAuth2ServiceProperties.getCodeParamName(), (String)  authentication.getCredentials());
 
-        ClientResponse clientResponse = webResource.accept(MediaType.APPLICATION_JSON_TYPE)
-                .get(ClientResponse.class);
+        WebResource webResource = client.resource(oAuth2ServiceProperties.getAccessTokenUri());
+        ClientResponse clientResponse = webResource
+                .accept(MediaType.APPLICATION_JSON_TYPE)
+                .type(MediaType.APPLICATION_FORM_URLENCODED)
+                .post(ClientResponse.class, values);
 
         return clientResponse;
     }

--- a/src/main/java/com/racquettrack/security/oauth/OAuth2AuthenticationToken.java
+++ b/src/main/java/com/racquettrack/security/oauth/OAuth2AuthenticationToken.java
@@ -1,9 +1,9 @@
 package com.racquettrack.security.oauth;
 
+import java.util.Collection;
+
 import org.springframework.security.authentication.AbstractAuthenticationToken;
 import org.springframework.security.core.GrantedAuthority;
-
-import java.util.Collection;
 
 /**
  * Implementation of an {@link AbstractAuthenticationToken}. This will typically be created by a
@@ -24,6 +24,7 @@ public class OAuth2AuthenticationToken extends AbstractAuthenticationToken {
 
     private Object credential = null;
     private Object principal = null;
+    private String redirectUri = null;
 
     /**
      * Instantiates an {@link OAuth2AuthenticationToken} with just a {@link #credential}. This constructor
@@ -73,4 +74,22 @@ public class OAuth2AuthenticationToken extends AbstractAuthenticationToken {
     public Object getPrincipal() {
         return principal;
     }
+
+    /**
+     * Gets the redirect URI where this authentication token response should be sent
+     * @return redirectUri as an absolute URI in string form or null
+     */
+    public String getRedirectUri() {
+        return redirectUri;
+    }
+
+    /**
+     * Sets the redirect URI where this authentication token response should be sent
+     * @param redirectUri an absolute URI in string form or null
+     */
+    public void setRedirectUri(String redirectUri) {
+        this.redirectUri = redirectUri;
+    }
+
+
 }

--- a/src/main/java/com/racquettrack/security/oauth/OAuth2ServiceProperties.java
+++ b/src/main/java/com/racquettrack/security/oauth/OAuth2ServiceProperties.java
@@ -1,6 +1,10 @@
 package com.racquettrack.security.oauth;
 
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.Map;
+
+import javax.servlet.http.HttpServletRequest;
 
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.util.Assert;
@@ -84,12 +88,47 @@ public class OAuth2ServiceProperties implements InitializingBean {
         this.additionalAuthParams = additionalAuthParams;
     }
 
+    /**
+     * The redirectUri which will handle responses from the OAuth2 provider.
+     * Can be relative or absolute
+     * @return
+     */
     public String getRedirectUri() {
         return redirectUri;
     }
 
+    /**
+     * The redirectUri which will handle responses from the OAuth2 provider.
+     * Can be relative or absolute
+     * @param redirectUri
+     */
     public void setRedirectUri(String redirectUri) {
         this.redirectUri = redirectUri;
+    }
+
+    /**
+     * If redirectUri is absolute then this method will return redirectUri.
+     * Otherwise the redirectUri's path will be combined with the incoming
+     * servlet request to form an absolute URI relevant to the servlet request
+     *
+     * @see getRedirectUri
+     * @return The absolute redirectUri in the form of a string
+     */
+    public String getAbsoluteRedirectUri(HttpServletRequest request) {
+        URI redirectUri = URI.create(this.getRedirectUri());
+        if (!redirectUri.isAbsolute()) {
+            URI requestUri = URI.create(request.getRequestURL().toString());
+            String newPath = request.getContextPath() +
+                    (redirectUri.getPath().startsWith("/") ? "" : "/" )+
+                    redirectUri.getPath();
+            try {
+                redirectUri = new URI(requestUri.getScheme(), null, requestUri.getHost(), requestUri.getPort(), newPath, null, null);
+            } catch (URISyntaxException e) {
+                return null;
+            }
+        }
+
+        return redirectUri.toString();
     }
 
     public String getAccessTokenUri() {

--- a/src/main/java/com/racquettrack/security/oauth/OAuth2ServiceProperties.java
+++ b/src/main/java/com/racquettrack/security/oauth/OAuth2ServiceProperties.java
@@ -1,9 +1,9 @@
 package com.racquettrack.security.oauth;
 
+import java.util.Map;
+
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.util.Assert;
-
-import java.util.Map;
 
 /**
  * Contains configuration properties for the OAuth2 Service Provider to authenticate against.
@@ -37,6 +37,7 @@ public class OAuth2ServiceProperties implements InitializingBean {
     private String clientId = null;
     private String clientSecret = null;
     private String userInfoUri = null;
+    private Map<String, String> additionalInfoParams = null;
 
     // Optional properties
     private String accessTokenName = DEFAULT_ACCESS_TOKEN_NAME;
@@ -177,6 +178,14 @@ public class OAuth2ServiceProperties implements InitializingBean {
 
     public void setUserInfoUri(String userInfoUri) {
         this.userInfoUri = userInfoUri;
+    }
+
+    public Map<String, String> getAdditionalInfoParams() {
+        return additionalInfoParams;
+    }
+
+    public void setAdditionalInfoParams(Map<String, String> additionalInfoParams) {
+        this.additionalInfoParams = additionalInfoParams;
     }
 
     public String getUserIdName() {

--- a/src/main/java/com/racquettrack/security/oauth/OAuth2UserDetailsLoader.java
+++ b/src/main/java/com/racquettrack/security/oauth/OAuth2UserDetailsLoader.java
@@ -1,9 +1,8 @@
 package com.racquettrack.security.oauth;
 
-import org.springframework.security.core.userdetails.UserDetails;
-
 import java.util.Map;
-import java.util.UUID;
+
+import org.springframework.security.core.userdetails.UserDetails;
 
 /**
  * Interface that allows for retrieving a {@link UserDetails} object from the internal system and for creating
@@ -18,10 +17,10 @@ public interface OAuth2UserDetailsLoader<T extends UserDetails> {
 
     /**
      * Retrieves the {@link UserDetails} object.
-     * @param uuid The {@link UUID} of the user in the OAuth Provider's system.
+     * @param id The ID of the user in the OAuth Provider's system.
      * @return The {@link UserDetails} of the user if it exists, or null if it doesn't.
      */
-    public T getUserByUserId(UUID uuid);
+    public T getUserByUserId(String id);
 
     /**
      * Expected to be called only when the user described by {@param userInfo} has already been determined to not
@@ -40,7 +39,7 @@ public interface OAuth2UserDetailsLoader<T extends UserDetails> {
      * @param userInfo The user info object returned from the OAuth Provider.
      * @return The created {@link UserDetails} object.
      */
-    public UserDetails createUser(UUID id, Map<String, Object> userInfo);
+    public UserDetails createUser(String id, Map<String, Object> userInfo);
 
     /**
      * Update the user with the information from the external system.

--- a/src/main/java/com/racquettrack/security/oauth/OAuth2UserDetailsService.java
+++ b/src/main/java/com/racquettrack/security/oauth/OAuth2UserDetailsService.java
@@ -1,5 +1,8 @@
 package com.racquettrack.security.oauth;
 
+import java.util.Map;
+import java.util.UUID;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.InitializingBean;
@@ -8,9 +11,6 @@ import org.springframework.security.core.userdetails.AuthenticationUserDetailsSe
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.util.Assert;
-
-import java.util.Map;
-import java.util.UUID;
 
 /**
  * An abstract implementation of an OAuth
@@ -55,7 +55,7 @@ public class OAuth2UserDetailsService implements
                     + token);
         }
 
-        UUID userId = getUserId(userInfo);
+        String userId = getUserId(userInfo);
 
         UserDetails userDetails = oAuth2UserDetailsLoader.getUserByUserId(userId);
 
@@ -93,9 +93,8 @@ public class OAuth2UserDetailsService implements
      * @param userInfo The JSON string converted into a {@link Map}.
      * @return The user id, a {@link UUID}.
      */
-    protected UUID getUserId(Map<String, Object> userInfo) {
-        String uuid = (String)userInfo.get(oAuth2ServiceProperties.getUserIdName());
-        return UUID.fromString(uuid);
+    protected String getUserId(Map<String, Object> userInfo) {
+        return (String)userInfo.get(oAuth2ServiceProperties.getUserIdName());
     }
 
     /**

--- a/src/test/java/com/racquettrack/security/oauth/AbstractOAuth2Test.java
+++ b/src/test/java/com/racquettrack/security/oauth/AbstractOAuth2Test.java
@@ -1,14 +1,17 @@
 package com.racquettrack.security.oauth;
 
-import com.sun.jersey.api.client.Client;
-import com.sun.jersey.api.client.ClientResponse;
-import com.sun.jersey.api.client.WebResource;
-import org.mockito.Matchers;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Matchers.anyObject;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
 
 import javax.ws.rs.core.MediaType;
 
-import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.mock;
+import org.mockito.Matchers;
+
+import com.sun.jersey.api.client.Client;
+import com.sun.jersey.api.client.ClientResponse;
+import com.sun.jersey.api.client.WebResource;
 
 /**
  * Helper class for initialising mocks for OAuth testing.
@@ -35,6 +38,8 @@ public class AbstractOAuth2Test {
         given(client.resource(resourceUri)).willReturn(webResource);
         given(webResource.queryParam(Matchers.anyString(), Matchers.anyString())).willReturn(webResource);
         given(webResource.accept(MediaType.APPLICATION_JSON_TYPE)).willReturn(builder);
+        given(builder.type(MediaType.APPLICATION_FORM_URLENCODED)).willReturn(builder);
+        given(builder.post(eq(ClientResponse.class), anyObject())).willReturn(clientResponse);
         given(builder.get(ClientResponse.class)).willReturn(clientResponse);
         given(clientResponse.getStatus()).willReturn(200);
         given(clientResponse.getClientResponseStatus()).willReturn(ClientResponse.Status.OK);

--- a/src/test/java/com/racquettrack/security/oauth/DefaultOauth2UserInfoProviderTest.java
+++ b/src/test/java/com/racquettrack/security/oauth/DefaultOauth2UserInfoProviderTest.java
@@ -1,7 +1,15 @@
 package com.racquettrack.security.oauth;
 
-import com.sun.jersey.api.client.ClientHandlerException;
-import com.sun.jersey.api.client.ClientResponse;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+import static org.hamcrest.core.Is.is;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+import java.util.Collections;
+import java.util.Map;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.InjectMocks;
@@ -9,13 +17,8 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.springframework.security.core.Authentication;
 
-import java.util.Map;
-
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.notNullValue;
-import static org.hamcrest.Matchers.nullValue;
-import static org.hamcrest.core.Is.is;
-import static org.mockito.BDDMockito.given;
+import com.sun.jersey.api.client.ClientHandlerException;
+import com.sun.jersey.api.client.ClientResponse;
 
 /**
  * Tests for {@link DefaultOAuth2UserInfoProvider}.
@@ -100,5 +103,15 @@ public class DefaultOauth2UserInfoProviderTest extends AbstractOAuth2Test {
 
         // then
         assertThat(userInfo, nullValue());
+    }
+
+    @Test
+    public void shouldIncludeOptionalInfoParams() {
+        Map<String,String> additionalInfoParams = Collections.singletonMap("extra_param", "param_value");
+        given(oAuth2ServiceProperties.getAdditionalInfoParams()).willReturn(additionalInfoParams);
+
+        Map<String, Object> userInfo = defaultOAuth2UserInfoProvider.getUserInfoFromProvider(token);
+        assertThat(userInfo, notNullValue());
+        verify(webResource).queryParam("extra_param", "param_value");
     }
 }

--- a/src/test/java/com/racquettrack/security/oauth/OAuth2AuthenticationFilterTest.java
+++ b/src/test/java/com/racquettrack/security/oauth/OAuth2AuthenticationFilterTest.java
@@ -1,5 +1,16 @@
 package com.racquettrack.security.oauth;
 
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpSession;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
@@ -11,16 +22,6 @@ import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
 
-import javax.servlet.ServletException;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpSession;
-import java.io.IOException;
-import java.util.HashMap;
-import java.util.Map;
-
-import static org.junit.Assert.assertEquals;
-import static org.mockito.Mockito.mock;
-
 /**
  * Tests for the {@link OAuth2AuthenticationFilterTest} class.
  *
@@ -31,11 +32,13 @@ public class OAuth2AuthenticationFilterTest {
     private static final String MOCK_STATE_VALUE ="123456789a";
     private static final String MOCK_CODE_VALUE = "987654321a";
     private static final String MOCK_TOKEN_VALUE ="FOO-TOKEN";
+    private static final String MOCK_REDIRECT_URI = "http://example.com/mock/redirect";
+
     private OAuth2AuthenticationFilter filter = new OAuth2AuthenticationFilter("/some/url");
     private static final String mockUri = "/some/url";
     private static final String mockQueryString = "state=" + MOCK_STATE_VALUE + "&code=" + MOCK_CODE_VALUE;
 
-    private OAuth2ServiceProperties oAuth2ServiceProperties = new OAuth2ServiceProperties();
+    private OAuth2ServiceProperties mockoAuth2ServiceProperties = Mockito.mock(OAuth2ServiceProperties.class);
 
     private HttpSession httpSession = Mockito.mock(HttpSession.class);
     private HttpServletRequest httpServletRequest = Mockito.mock(HttpServletRequest.class);
@@ -46,7 +49,7 @@ public class OAuth2AuthenticationFilterTest {
 
     @Before
     public void setup() {
-        filter.setoAuth2ServiceProperties(oAuth2ServiceProperties);
+        filter.setoAuth2ServiceProperties(mockoAuth2ServiceProperties);
         filter.setAuthenticationManager(authenticationManager);
 
         parameters.put("state", new String[] {MOCK_STATE_VALUE});
@@ -56,7 +59,10 @@ public class OAuth2AuthenticationFilterTest {
         Mockito.when(httpServletRequest.getParameterMap()).thenReturn(parameters);
         Mockito.when(httpServletRequest.getRequestURI()).thenReturn(mockUri);
         Mockito.when(httpServletRequest.getQueryString()).thenReturn(mockQueryString);
-
+        Mockito.when(mockoAuth2ServiceProperties.getAbsoluteRedirectUri(httpServletRequest)).thenReturn(MOCK_REDIRECT_URI);
+        Mockito.when(mockoAuth2ServiceProperties.getRedirectUri()).thenReturn(MOCK_REDIRECT_URI);
+        Mockito.when(mockoAuth2ServiceProperties.getStateParamName()).thenReturn(new OAuth2ServiceProperties().getStateParamName());
+        Mockito.when(mockoAuth2ServiceProperties.getCodeParamName()).thenReturn(new OAuth2ServiceProperties().getCodeParamName());
         Mockito.when(httpSession.getAttribute("state")).thenReturn(MOCK_STATE_VALUE);
 
         expectedAuthRequest.setDetails(authenticationDetailsSource.buildDetails(httpServletRequest));

--- a/src/test/java/com/racquettrack/security/oauth/OAuth2AuthenticationProviderTest.java
+++ b/src/test/java/com/racquettrack/security/oauth/OAuth2AuthenticationProviderTest.java
@@ -1,7 +1,13 @@
 package com.racquettrack.security.oauth;
 
-import com.sun.jersey.api.client.ClientHandlerException;
-import com.sun.jersey.api.client.ClientResponse;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Matchers.anyObject;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
+
 import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.Before;
 import org.junit.Test;
@@ -10,11 +16,8 @@ import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.core.userdetails.AuthenticationUserDetailsService;
 import org.springframework.security.core.userdetails.UserDetails;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.notNullValue;
-import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.mock;
+import com.sun.jersey.api.client.ClientHandlerException;
+import com.sun.jersey.api.client.ClientResponse;
 
 /**
  * Tests for {@link OAuth2AuthenticationProvider}.
@@ -83,7 +86,7 @@ public class OAuth2AuthenticationProviderTest extends AbstractOAuth2Test {
     @Test(expected = AuthenticationException.class)
     public void shouldThrowAuthenticationExceptionWhenJerseyThrowsARuntimeError() {
         // given
-        given(builder.get(ClientResponse.class)).willThrow(ClientHandlerException.class);
+        given(builder.post(eq(ClientResponse.class), anyObject())).willThrow(ClientHandlerException.class);
 
         // when
         oAuth2AuthenticationProvider.authenticate(oAuth2AuthenticationToken);

--- a/src/test/java/com/racquettrack/security/oauth/OAuth2ServicePropertiesTest.java
+++ b/src/test/java/com/racquettrack/security/oauth/OAuth2ServicePropertiesTest.java
@@ -1,0 +1,58 @@
+package com.racquettrack.security.oauth;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.IsEqual.equalTo;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+
+import java.io.IOException;
+
+import javax.servlet.http.HttpServletRequest;
+
+import org.junit.Before;
+import org.junit.Test;
+
+public class OAuth2ServicePropertiesTest extends AbstractOAuth2Test {
+
+    final String ABSOLUTE_URI = "http://fake.example.org/absolute/uri";
+    final String SOURCE_URI = "http://my.custom.domain/context/resource.request?foo=bar";
+    final String SOURCE_CONTEXT = "/context";
+    final String RELATIVE_URI = "/relative/uri.example";
+    final String RELATIVE_URI_NOSLASH = "relative/uri.example";
+
+    OAuth2ServiceProperties properties;
+    HttpServletRequest mockRequest = mock(HttpServletRequest.class);
+
+    @Before
+    public void setup() throws IOException {
+        properties = new OAuth2ServiceProperties();
+
+    }
+
+    @Test
+    public void shouldNotChangeAbsoluteRedirectUri() throws IOException {
+        properties.setRedirectUri(ABSOLUTE_URI);
+
+        assertThat(properties.getAbsoluteRedirectUri(mockRequest), equalTo(ABSOLUTE_URI));
+    }
+
+    @Test
+    public void shouldChangeRelativeRedirectUri() throws IOException {
+        properties.setRedirectUri(RELATIVE_URI);
+
+        given(mockRequest.getRequestURL()).willReturn(new StringBuffer(SOURCE_URI));
+        given(mockRequest.getContextPath()).willReturn(SOURCE_CONTEXT);
+
+        assertThat(properties.getAbsoluteRedirectUri(mockRequest), equalTo("http://my.custom.domain/context/relative/uri.example"));
+    }
+
+    @Test
+    public void shouldChangeRelativeNoSlashRedirectUri() throws IOException {
+        properties.setRedirectUri(RELATIVE_URI_NOSLASH);
+
+        given(mockRequest.getRequestURL()).willReturn(new StringBuffer(SOURCE_URI));
+        given(mockRequest.getContextPath()).willReturn(SOURCE_CONTEXT);
+
+        assertThat(properties.getAbsoluteRedirectUri(mockRequest), equalTo("http://my.custom.domain/context/relative/uri.example"));
+    }
+}

--- a/src/test/java/com/racquettrack/security/oauth/OAuth2UserDetailsServiceTest.java
+++ b/src/test/java/com/racquettrack/security/oauth/OAuth2UserDetailsServiceTest.java
@@ -1,21 +1,25 @@
 package com.racquettrack.security.oauth;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyMapOf;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import java.io.IOException;
+import java.util.Calendar;
+import java.util.Map;
+
 import org.codehaus.jackson.map.ObjectMapper;
 import org.codehaus.jackson.type.TypeReference;
 import org.junit.Before;
 import org.junit.Test;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
-
-import java.io.IOException;
-import java.util.Calendar;
-import java.util.Map;
-import java.util.UUID;
-
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.core.Is.is;
-import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.*;
 
 /**
  * Tests for the {@link OAuth2UserDetailsService}.
@@ -37,7 +41,7 @@ public class OAuth2UserDetailsServiceTest {
     private OAuth2UserDetailsService oAuth2UserDetailsService = new OAuth2UserDetailsService();
     private OAuth2ServiceProperties oAuth2ServiceProperties = new OAuth2ServiceProperties();
     private OAuth2AuthenticationToken oAuth2AuthenticationToken = new OAuth2AuthenticationToken(MOCK_ACCESS_TOKEN);
-    private UUID userId = UUID.fromString(MOCK_USER_UUID);
+    private String userId = MOCK_USER_UUID;
     private Map<String, Object> userInfoResponse;
 
     // Mocks
@@ -107,7 +111,7 @@ public class OAuth2UserDetailsServiceTest {
         UserDetails ud = oAuth2UserDetailsService.loadUserDetails(oAuth2AuthenticationToken);
 
         // then
-        verify(oAuth2UserDetailsLoader, never()).createUser(any(UUID.class), anyMapOf(String.class, Object.class));
+        verify(oAuth2UserDetailsLoader, never()).createUser(any(String.class), anyMapOf(String.class, Object.class));
         verify(oAuth2UserDetailsLoader).updateUser(ud, userInfoResponse);
         assertThat(user, is(ud));
     }


### PR DESCRIPTION
We've extended this library for use with google, the following is the reader's digest of changes:
- redirectUri can now be relative or absolute
- UUID's were replaced with strings (to support Google)
- spring was upgraded to 3.2.4
